### PR TITLE
Made Hero & its associated components responsive

### DIFF
--- a/components/Form.tsx
+++ b/components/Form.tsx
@@ -67,24 +67,23 @@ export default function Form() {
 
   return (
     <>
-      <form className="mb-6 flex flex-col items-center " onSubmit={send}>
-        <label className="block mb-2 text-sm font-medium text-white dark:text-white">
+      <form className="mb-6 flex flex-col items-center" onSubmit={send}>
+        <label className="block mb-2 text-sm font-medium text-white dark:text-white max-md:text-xs">
           Type a website url
         </label>
         <input
           onChange={update}
           type="text"
           id="success"
-          className="md:w-[50rem] w-[20rem] bg-green-50 border border-blue-500 text-blue-900 dark:text-blue-400 placeholder-black-700 dark:placeholder-black-500 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block  p-2.5 dark:bg-gray-700 dark:border-blue-500 mb-5"
+          className="lg:w-[50rem] w-[20rem] bg-green-50 border border-blue-500 text-blue-900 dark:text-blue-400 placeholder-black-700 dark:placeholder-black-500 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block p-2.5 dark:bg-gray-700 dark:border-blue-500 mb-5 max-lg:text-sm max-md:text-xs max-sm:p-2 max-sm:w-[85%]"
           placeholder="https://www.example.com"
         />
 
-        <MagicButton
-          title={load ? "Downloading..." : "Download now"}
-          // onClick={send}
-          type="submit"
-          disabled={load}
-        />
+          <MagicButton
+            title={load ? "Downloading..." : "Download now"}
+            type="submit"
+            disabled={load}
+          />
 
         {err && <Snackbar state={err} setstate={seterr} />}
       </form>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -10,19 +10,21 @@ import { LampContainer } from "./ui/LampEffect";
 export default function Hero() {
   return (
     <>
-      <div className="relative h-screen flex flex-col justify-center items-center">
+      <>
+      <div className="relative h-screen flex flex-col justify-center items-center max-sm:px-2 ">
         <LampContainer>
-          <div className="text-center w-full max-w-xl">
+          <div className="text-center w-full max-w-xl max-lg:mb-[-18px]">
             {/* Unlock insights from the web with our powerful web scraper */}
             {/* <TypewriterEffectSmoothDemo /> */}
             <HeroTypingEffect />
           </div>
-          <div className="md:w-[50rem] w-[20rem] flex flex-col items-center ">
+          <div className="w-full max-w-xl max-lg:mt-12 max-md:mt-8 max-sm:mt-6">
             <Form />
           </div>
         </LampContainer>
       </div>
-      <Testimonials/>
+      <Testimonials />
+    </>
     </>
   );
 }

--- a/components/HeroTypingEffect.tsx
+++ b/components/HeroTypingEffect.tsx
@@ -3,8 +3,8 @@ import Typewriter from "typewriter-effect";
 
 const HeroTypingEffect = () => {
   return (
-    <div className="text-lg md:text-3xl font-bold mt-6 mb-0 lg:mt-16 lg:mb-8 ">
-      <div className="text-blue-900">
+    <div className="text-3xl font-bold mt-6 mb-0 lg:mt-16 lg:mb-8 max-lg:text-2xl max-md:text-xl max-sm:text-base max-md:mt-8 max-md:mb-4 max-sm:mt-6 ">
+      <div className="text-blue-900 max-lg:mt-12">
         <Typewriter
           onInit={(typewriter) => {
             typewriter
@@ -20,14 +20,12 @@ const HeroTypingEffect = () => {
           }}
         />
       </div>
-      <div className="text-blue-900 lg:text-cyan-400 ">
-        {" "}
+      <div className="text-cyan-400 max-lg:text-blue-900">
         <Typewriter
           onInit={(typewriter) => {
             typewriter
               .pauseFor(2000)
               .typeString("with our powerful web scraper")
-
               .start()
               .callFunction(() => {
                 typewriter.stop();

--- a/components/ui/TypeWriter.tsx
+++ b/components/ui/TypeWriter.tsx
@@ -175,12 +175,11 @@ export const TypewriterEffectSmooth = ({
         }}
         transition={{
           duration: 0.8,
-
           repeat: Infinity,
           repeatType: "reverse",
         }}
         className={cn(
-          "block rounded-sm w-[4px]  h-11 bg-blue-500",
+          "block rounded-sm w-[4px] h-11 max-lg:h-9 max-md:h-7 max-sm:h-6 bg-blue-500",
           cursorClassName
         )}
       ></motion.span>


### PR DESCRIPTION
# Description

- Added responsiveness to Hero section of our website
- Our website is now responsive for various screen sizes like 1024px, 768px, 425px, 375px & 320px
- Along with `Hero` component, components like `TypeWriter`, `HeroTypingEffect` and `Form` are also made responsive 

Fixes:  #155 

<!---give the issue number you fixed----->

## Type of change

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->
- [X] I have made this from my own
- [ ] I have taken help from some online resourses 
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings


# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK


https://github.com/Abidsyed25/ScrapQuest/assets/115717746/6951c896-1162-4ace-a1cb-658713fd04f7




